### PR TITLE
Allow HACS preview workflow to comment

### DIFF
--- a/.github/workflows/hacs-preview.yml
+++ b/.github/workflows/hacs-preview.yml
@@ -23,6 +23,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  issues: write
   checks: read
 
 env:


### PR DESCRIPTION
Adds the missing issues: write permission so automatic HACS preview runs can post the preview release comment after creating the pre-release.