### PR TITLE
Keep latest five HACS preview releases per PR

### DIFF
--- a/.github/workflows/hacs-preview.yml
+++ b/.github/workflows/hacs-preview.yml
@@ -1,0 +1,287 @@
+name: HACS Preview Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to publish as preview
+        required: true
+        type: number
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: read
+  checks: read
+
+concurrency:
+  group: hacs-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup-preview:
+    name: Clean up preview release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    steps:
+      - name: Delete preview releases for PR
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = process.env.PR_NUMBER;
+
+            const deleteReleaseAndTag = async (release) => {
+              core.info(`Deleting preview release ${release.tag_name}`);
+              await github.rest.repos.deleteRelease({
+                owner,
+                repo,
+                release_id: release.id,
+              });
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `tags/${release.tag_name}`,
+                });
+              } catch (error) {
+                core.warning(`Could not delete tag ${release.tag_name}: ${error.message}`);
+              }
+            };
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const matching = releases.filter((release) =>
+              release.prerelease &&
+              typeof release.body === "string" &&
+              release.body.includes("Managed-By: hacs-preview") &&
+              release.body.includes(`Preview-PR: ${prNumber}`)
+            );
+
+            for (const release of matching) {
+              await deleteReleaseAndTag(release);
+            }
+
+  publish-preview:
+    name: Publish preview release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.action != 'closed'
+    steps:
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.eventName === "workflow_dispatch"
+              ? Number(core.getInput("pr_number"))
+              : context.payload.pull_request.number;
+
+            const { owner, repo } = context.repo;
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.state !== "open") {
+              core.setFailed(`PR #${prNumber} is not open.`);
+              return;
+            }
+
+            if (pr.draft) {
+              core.setFailed(`PR #${prNumber} is still a draft.`);
+              return;
+            }
+
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.setFailed(
+                "Preview releases are currently only supported for branches in the main repository."
+              );
+              return;
+            }
+
+            core.setOutput("number", String(pr.number));
+            core.setOutput("head_sha", pr.head.sha);
+            core.setOutput("head_ref", pr.head.ref);
+
+      - name: Verify required checks
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = process.env.HEAD_SHA;
+            const requiredChecks = new Map([
+              ["Code Quality", false],
+              ["✅ All Tests Passed", false],
+              ["HACS Action", false],
+              ["validate", false],
+            ]);
+
+            const { data: checkRuns } = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref: sha,
+              per_page: 100,
+            });
+
+            for (const check of checkRuns.check_runs) {
+              if (!requiredChecks.has(check.name)) {
+                continue;
+              }
+              if (check.status !== "completed") {
+                core.setFailed(`Check '${check.name}' is still ${check.status}.`);
+                return;
+              }
+              if (check.conclusion !== "success") {
+                core.setFailed(`Check '${check.name}' concluded with '${check.conclusion}'.`);
+                return;
+              }
+              requiredChecks.set(check.name, true);
+            }
+
+            const missing = [...requiredChecks.entries()]
+              .filter(([, seen]) => !seen)
+              .map(([name]) => name);
+            if (missing.length > 0) {
+              core.setFailed(`Missing successful checks for ${sha}: ${missing.join(", ")}`);
+            }
+
+      - name: Remove outdated preview for this PR and compute next sequence
+        id: sequence
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_PR: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = process.env.PREVIEW_PR;
+
+            const deleteReleaseAndTag = async (release) => {
+              core.info(`Deleting preview release ${release.tag_name}`);
+              await github.rest.repos.deleteRelease({
+                owner,
+                repo,
+                release_id: release.id,
+              });
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `tags/${release.tag_name}`,
+                });
+              } catch (error) {
+                core.warning(`Could not delete tag ${release.tag_name}: ${error.message}`);
+              }
+            };
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const matching = releases.filter((release) =>
+              release.prerelease &&
+              typeof release.body === "string" &&
+              release.body.includes("Managed-By: hacs-preview") &&
+              release.body.includes(`Preview-PR: ${prNumber}`)
+            );
+
+            let nextSequence = 1;
+            for (const release of matching) {
+              const match = release.tag_name.match(new RegExp(`^preview-pr-${prNumber}-(\\d+)$`));
+              if (match) {
+                nextSequence = Math.max(nextSequence, Number(match[1]) + 1);
+              }
+            }
+
+            for (const release of matching) {
+              await deleteReleaseAndTag(release);
+            }
+
+            core.setOutput("value", String(nextSequence));
+
+      - name: Create preview release
+        id: release
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_PR: ${{ steps.pr.outputs.number }}
+          PREVIEW_SHA: ${{ steps.pr.outputs.head_sha }}
+          PREVIEW_REF: ${{ steps.pr.outputs.head_ref }}
+          PREVIEW_SEQUENCE: ${{ steps.sequence.outputs.value }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = process.env.PREVIEW_PR;
+            const sha = process.env.PREVIEW_SHA;
+            const ref = process.env.PREVIEW_REF;
+            const sequence = process.env.PREVIEW_SEQUENCE;
+            const tag = `preview-pr-${prNumber}-${sequence}`;
+            const name = `Preview PR #${prNumber} (${sequence})`;
+            const body = [
+              "Automated preview release for HACS testing.",
+              "",
+              `Preview-PR: ${prNumber}`,
+              `Preview-Sequence: ${sequence}`,
+              `Branch: ${ref}`,
+              `Commit: ${sha}`,
+              "Managed-By: hacs-preview",
+              "",
+              "This preview is deleted automatically when the PR is closed or merged.",
+            ].join("\n");
+
+            const { data: created } = await github.rest.repos.createRelease({
+              owner,
+              repo,
+              tag_name: tag,
+              target_commitish: sha,
+              name,
+              body,
+              prerelease: true,
+              draft: false,
+              make_latest: "false",
+            });
+
+            core.setOutput("html_url", created.html_url);
+            core.setOutput("tag", created.tag_name);
+
+      - name: Comment on pull request
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          RELEASE_URL: ${{ steps.release.outputs.html_url }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const body = [
+              "Created a HACS preview pre-release for this PR.",
+              "",
+              `Tag: \`${process.env.RELEASE_TAG}\``,
+              `Release: ${process.env.RELEASE_URL}`,
+              "",
+              "A newer preview for this PR will replace the current one automatically.",
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });

--- a/.github/workflows/hacs-preview.yml
+++ b/.github/workflows/hacs-preview.yml
@@ -127,7 +127,6 @@ jobs:
             const requiredChecks = new Map([
               ["Code Quality", false],
               ["✅ All Tests Passed", false],
-              ["HACS Action", false],
               ["validate", false],
             ]);
 

--- a/.github/workflows/hacs-preview.yml
+++ b/.github/workflows/hacs-preview.yml
@@ -1,6 +1,11 @@
 name: HACS Preview Release
 
 on:
+  release:
+    types:
+      - published
+  schedule:
+    - cron: "*/10 * * * *"
   workflow_dispatch:
     inputs:
       pr_number:
@@ -20,18 +25,83 @@ permissions:
   pull-requests: read
   checks: read
 
+env:
+  HACS_PREVIEW_PR_NUMBERS: ${{ vars.HACS_PREVIEW_PR_NUMBERS || vars.HACS_PREVIEW_PR_NUMBER }}
+
 concurrency:
-  group: hacs-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: hacs-preview-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  cleanup-preview-on-release:
+    name: Clean up merged previews on stable release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.release.prerelease == false
+    steps:
+      - name: Delete merged preview releases
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            const deleteReleaseAndTag = async (release) => {
+              core.info(`Deleting preview release ${release.tag_name}`);
+              await github.rest.repos.deleteRelease({
+                owner,
+                repo,
+                release_id: release.id,
+              });
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `tags/${release.tag_name}`,
+                });
+              } catch (error) {
+                core.warning(`Could not delete tag ${release.tag_name}: ${error.message}`);
+              }
+            };
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const previews = releases.filter((release) =>
+              release.prerelease &&
+              typeof release.body === "string" &&
+              release.body.includes("Managed-By: hacs-preview")
+            );
+
+            for (const release of previews) {
+              const match = release.body.match(/Preview-PR: (\\d+)/);
+              if (!match) {
+                continue;
+              }
+
+              const prNumber = Number(match[1]);
+              try {
+                const { data: pr } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                });
+                if (pr.merged_at) {
+                  await deleteReleaseAndTag(release);
+                }
+              } catch (error) {
+                core.warning(`Could not inspect PR #${prNumber} for ${release.tag_name}: ${error.message}`);
+              }
+            }
+
   cleanup-preview:
     name: Clean up preview release
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
     steps:
       - name: Delete preview releases for PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
@@ -74,39 +144,131 @@ jobs:
               await deleteReleaseAndTag(release);
             }
 
+  resolve-preview-targets:
+    name: Resolve preview targets
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.action != 'closed'
+      )
+    outputs:
+      has_targets: ${{ steps.targets.outputs.has_targets }}
+      matrix: ${{ steps.targets.outputs.matrix }}
+    steps:
+      - name: Resolve allowed pull requests
+        id: targets
+        uses: actions/github-script@v8
+        env:
+          ALLOWED_PREVIEW_PR_NUMBERS: ${{ vars.HACS_PREVIEW_PR_NUMBERS || vars.HACS_PREVIEW_PR_NUMBER }}
+        with:
+          script: |
+            const parseAllowedPrNumbers = () => [
+              ...new Set(
+                (process.env.ALLOWED_PREVIEW_PR_NUMBERS || "")
+                  .split(",")
+                  .map((value) => Number(value.trim()))
+                  .filter((value) => Number.isInteger(value) && value > 0)
+              ),
+            ];
+
+            const allowedPrNumbers = parseAllowedPrNumbers();
+            let targetPrNumbers = [];
+
+            if (context.eventName === "workflow_dispatch") {
+              const raw = context.payload.inputs?.pr_number;
+              if (!raw || Number.isNaN(Number(raw)) || Number(raw) <= 0) {
+                core.setFailed("workflow_dispatch requires a valid pr_number greater than 0.");
+                return;
+              }
+              targetPrNumbers = [Number(raw)];
+            } else if (context.eventName === "schedule") {
+              targetPrNumbers = allowedPrNumbers;
+            } else {
+              const prNumber = context.payload.pull_request?.number;
+              if (!prNumber || prNumber <= 0) {
+                core.setFailed(`No valid pull request number found in ${context.eventName} payload.`);
+                return;
+              }
+              if (allowedPrNumbers.includes(Number(prNumber))) {
+                targetPrNumbers = [Number(prNumber)];
+              }
+            }
+
+            core.info(`Allowed preview PRs: ${allowedPrNumbers.join(", ") || "(none)"}`);
+            core.info(`Resolved preview targets: ${targetPrNumbers.join(", ") || "(none)"}`);
+            core.setOutput("matrix", JSON.stringify(targetPrNumbers));
+            core.setOutput("has_targets", targetPrNumbers.length > 0 ? "true" : "false");
+
   publish-preview:
     name: Publish preview release
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.action != 'closed'
+    needs: resolve-preview-targets
+    if: needs.resolve-preview-targets.outputs.has_targets == 'true'
+    concurrency:
+      group: hacs-preview-pr-${{ matrix.pr_number }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        pr_number: ${{ fromJSON(needs.resolve-preview-targets.outputs.matrix) }}
     steps:
       - name: Resolve pull request
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
+        env:
+          TARGET_PR_NUMBER: ${{ matrix.pr_number }}
         with:
           script: |
-            const prNumber = context.eventName === "workflow_dispatch"
-              ? Number(core.getInput("pr_number"))
-              : context.payload.pull_request.number;
+            const prNumber = Number(process.env.TARGET_PR_NUMBER || "0");
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid preview target PR number '${process.env.TARGET_PR_NUMBER}'.`);
+              return;
+            }
 
             const { owner, repo } = context.repo;
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber,
-            });
+            const skipOrFail = (message) => {
+              if (context.eventName === "schedule") {
+                core.info(`${message}; skipping scheduled preview.`);
+                core.setOutput("number", String(prNumber));
+                core.setOutput("head_sha", "");
+                core.setOutput("head_ref", "");
+                core.setOutput("title", "");
+                core.setOutput("body", "");
+                core.setOutput("publishable", "false");
+                return;
+              }
+              core.setFailed(message);
+            };
+
+            let pr;
+            try {
+              const response = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              pr = response.data;
+            } catch (error) {
+              skipOrFail(`Could not inspect PR #${prNumber}: ${error.message}`);
+              return;
+            }
 
             if (pr.state !== "open") {
-              core.setFailed(`PR #${prNumber} is not open.`);
+              skipOrFail(`PR #${prNumber} is not open.`);
               return;
             }
 
             if (pr.draft) {
-              core.setFailed(`PR #${prNumber} is still a draft.`);
+              skipOrFail(`PR #${prNumber} is still a draft.`);
               return;
             }
 
             if (pr.head.repo.full_name !== `${owner}/${repo}`) {
-              core.setFailed(
+              skipOrFail(
                 "Preview releases are currently only supported for branches in the main repository."
               );
               return;
@@ -115,53 +277,122 @@ jobs:
             core.setOutput("number", String(pr.number));
             core.setOutput("head_sha", pr.head.sha);
             core.setOutput("head_ref", pr.head.ref);
+            core.setOutput("title", pr.title ?? "");
+            core.setOutput("body", pr.body ?? "");
+            core.setOutput("publishable", "true");
 
-      - name: Verify required checks
-        uses: actions/github-script@v7
+      - name: Check preview freshness
+        id: freshness
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_PR: ${{ steps.pr.outputs.number }}
+          PREVIEW_SHA: ${{ steps.pr.outputs.head_sha }}
+          PREVIEW_PUBLISHABLE: ${{ steps.pr.outputs.publishable }}
+        with:
+          script: |
+            if (process.env.PREVIEW_PUBLISHABLE !== "true") {
+              core.setOutput("should_publish", "false");
+              return;
+            }
+
+            if (context.eventName !== "schedule") {
+              core.setOutput("should_publish", "true");
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const prNumber = process.env.PREVIEW_PR;
+            const sha = process.env.PREVIEW_SHA;
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const currentPreviewExists = releases.some((release) =>
+              release.prerelease &&
+              typeof release.body === "string" &&
+              release.body.includes("Managed-By: hacs-preview") &&
+              release.body.includes(`Preview-PR: ${prNumber}`) &&
+              release.body.includes(`Commit: ${sha}`)
+            );
+
+            if (currentPreviewExists) {
+              core.info(`Preview for PR #${prNumber} already points to ${sha}; skipping scheduled rebuild.`);
+              core.setOutput("should_publish", "false");
+              return;
+            }
+
+            core.info(`Preview for PR #${prNumber} is missing or outdated; publishing ${sha}.`);
+            core.setOutput("should_publish", "true");
+
+      - name: Wait for all done check
+        if: steps.freshness.outputs.should_publish == 'true'
+        uses: actions/github-script@v8
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const sha = process.env.HEAD_SHA;
-            const requiredChecks = new Map([
-              ["Code Quality", false],
-              ["✅ All Tests Passed", false],
-              ["validate", false],
-            ]);
+            const checkName = "✅ All Tests Passed";
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const maxAttempts = 20;
+            const delayMs = 30000;
 
-            const { data: checkRuns } = await github.rest.checks.listForRef({
-              owner,
-              repo,
-              ref: sha,
-              per_page: 100,
-            });
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: sha,
+                per_page: 100,
+              });
 
-            for (const check of checkRuns.check_runs) {
-              if (!requiredChecks.has(check.name)) {
+              const check = checkRuns.check_runs.find((run) => run.name === checkName);
+
+              if (!check) {
+                if (attempt === maxAttempts) {
+                  core.setFailed(`Timed out waiting for check '${checkName}' on ${sha}.`);
+                  return;
+                }
+                core.info(
+                  `Waiting for check '${checkName}' to appear on ${sha} ` +
+                  `(attempt ${attempt}/${maxAttempts}).`
+                );
+                await sleep(delayMs);
                 continue;
               }
-              if (check.status !== "completed") {
-                core.setFailed(`Check '${check.name}' is still ${check.status}.`);
-                return;
-              }
-              if (check.conclusion !== "success") {
-                core.setFailed(`Check '${check.name}' concluded with '${check.conclusion}'.`);
-                return;
-              }
-              requiredChecks.set(check.name, true);
-            }
 
-            const missing = [...requiredChecks.entries()]
-              .filter(([, seen]) => !seen)
-              .map(([name]) => name);
-            if (missing.length > 0) {
-              core.setFailed(`Missing successful checks for ${sha}: ${missing.join(", ")}`);
+              if (check.status !== "completed") {
+                if (attempt === maxAttempts) {
+                  core.setFailed(
+                    `Timed out waiting for check '${checkName}' to complete on ${sha}.`
+                  );
+                  return;
+                }
+                core.info(
+                  `Waiting for check '${checkName}' to complete on ${sha} ` +
+                  `(attempt ${attempt}/${maxAttempts}, status=${check.status}).`
+                );
+                await sleep(delayMs);
+                continue;
+              }
+
+              if (check.conclusion !== "success") {
+                core.setFailed(
+                  `Check '${checkName}' completed with conclusion '${check.conclusion}', no preview release will be created.`
+                );
+                return;
+              }
+
+              core.info(`Check '${checkName}' passed for ${sha}.`);
+              return;
             }
 
       - name: Remove outdated preview for this PR and compute next sequence
+        if: steps.freshness.outputs.should_publish == 'true'
         id: sequence
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PREVIEW_PR: ${{ steps.pr.outputs.number }}
         with:
@@ -200,11 +431,12 @@ jobs:
               release.body.includes(`Preview-PR: ${prNumber}`)
             );
 
-            let nextSequence = 1;
+            let nextSuffixNumber = 0;
             for (const release of matching) {
-              const match = release.tag_name.match(new RegExp(`^preview-pr-${prNumber}-(\\d+)$`));
+              const match = release.tag_name.match(new RegExp(`-pr${prNumber}(?:-(\\d+))?$`));
               if (match) {
-                nextSequence = Math.max(nextSequence, Number(match[1]) + 1);
+                const existingSuffixNumber = match[1] ? Number(match[1]) : 0;
+                nextSuffixNumber = Math.max(nextSuffixNumber, existingSuffixNumber + 1);
               }
             }
 
@@ -212,15 +444,18 @@ jobs:
               await deleteReleaseAndTag(release);
             }
 
-            core.setOutput("value", String(nextSequence));
+            core.setOutput("value", String(nextSuffixNumber));
 
       - name: Create preview release
+        if: steps.freshness.outputs.should_publish == 'true'
         id: release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PREVIEW_PR: ${{ steps.pr.outputs.number }}
           PREVIEW_SHA: ${{ steps.pr.outputs.head_sha }}
           PREVIEW_REF: ${{ steps.pr.outputs.head_ref }}
+          PREVIEW_TITLE: ${{ steps.pr.outputs.title }}
+          PREVIEW_BODY: ${{ steps.pr.outputs.body }}
           PREVIEW_SEQUENCE: ${{ steps.sequence.outputs.value }}
         with:
           script: |
@@ -228,20 +463,58 @@ jobs:
             const prNumber = process.env.PREVIEW_PR;
             const sha = process.env.PREVIEW_SHA;
             const ref = process.env.PREVIEW_REF;
-            const sequence = process.env.PREVIEW_SEQUENCE;
-            const tag = `preview-pr-${prNumber}-${sequence}`;
-            const name = `Preview PR #${prNumber} (${sequence})`;
-            const body = [
-              "Automated preview release for HACS testing.",
+            const prTitle = (process.env.PREVIEW_TITLE || "").trim();
+            const prBody = (process.env.PREVIEW_BODY || "").trim();
+            const suffixNumber = Number(process.env.PREVIEW_SEQUENCE || "0");
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const stable = releases.find((release) => !release.prerelease && !release.draft);
+
+            const nextStableVersion = (() => {
+              const fallback = "0.0.1";
+              if (!stable?.tag_name) {
+                return fallback;
+              }
+              const match = stable.tag_name.match(/^(\\d+)\\.(\\d+)\\.(\\d+)$/);
+              if (!match) {
+                return fallback;
+              }
+              const year = Number(match[1]);
+              const month = Number(match[2]);
+              const patch = Number(match[3]) + 1;
+              return `${year}.${String(month).padStart(2, "0")}.${patch}`;
+            })();
+            const suffix = suffixNumber === 0 ? "" : `-${suffixNumber}`;
+            const tag = `${nextStableVersion}-pr${prNumber}${suffix}`;
+            const name = tag;
+
+            const visibleBodyParts = [];
+            if (prTitle) {
+              visibleBodyParts.push(prTitle);
+            }
+            if (prBody) {
+              visibleBodyParts.push("", prBody);
+            }
+            visibleBodyParts.push(
               "",
-              `Preview-PR: ${prNumber}`,
-              `Preview-Sequence: ${sequence}`,
-              `Branch: ${ref}`,
-              `Commit: ${sha}`,
-              "Managed-By: hacs-preview",
+              "---",
               "",
-              "This preview is deleted automatically when the PR is closed or merged.",
-            ].join("\n");
+              "Preview release for testing this PR in HACS.",
+              "It is automatically replaced when the PR is updated and removed when the PR is closed or merged."
+            );
+
+            const hiddenMetadata = [
+              `<!-- Managed-By: hacs-preview -->`,
+              `<!-- Preview-PR: ${prNumber} -->`,
+              `<!-- Preview-Sequence: ${suffixNumber} -->`,
+              `<!-- Branch: ${ref} -->`,
+              `<!-- Commit: ${sha} -->`,
+            ];
+
+            const body = [...visibleBodyParts, "", ...hiddenMetadata].join("\n");
 
             const { data: created } = await github.rest.repos.createRelease({
               owner,
@@ -259,8 +532,8 @@ jobs:
             core.setOutput("tag", created.tag_name);
 
       - name: Comment on pull request
-        if: github.event_name != 'workflow_dispatch'
-        uses: actions/github-script@v7
+        if: steps.freshness.outputs.should_publish == 'true' && github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           RELEASE_URL: ${{ steps.release.outputs.html_url }}

--- a/.github/workflows/hacs-preview.yml
+++ b/.github/workflows/hacs-preview.yml
@@ -335,7 +335,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const sha = process.env.HEAD_SHA;
-            const checkName = "✅ All Tests Passed";
+            const checkName = "✅ All Checks Passed";
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
             const maxAttempts = 20;
             const delayMs = 30000;

--- a/.github/workflows/hacs-preview.yml
+++ b/.github/workflows/hacs-preview.yml
@@ -22,7 +22,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
   issues: write
   checks: read
 
@@ -534,6 +534,7 @@ jobs:
 
       - name: Comment on pull request
         if: steps.freshness.outputs.should_publish == 'true' && github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
+        continue-on-error: true
         uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/hacs-preview.yml
+++ b/.github/workflows/hacs-preview.yml
@@ -76,7 +76,7 @@ jobs:
             );
 
             for (const release of previews) {
-              const match = release.body.match(/Preview-PR: (\\d+)/);
+              const match = release.body.match(/Preview-PR: (\d+)/);
               if (!match) {
                 continue;
               }
@@ -134,12 +134,17 @@ jobs:
               per_page: 100,
             });
 
-            const matching = releases.filter((release) =>
-              release.prerelease &&
-              typeof release.body === "string" &&
-              release.body.includes("Managed-By: hacs-preview") &&
-              release.body.includes(`Preview-PR: ${prNumber}`)
-            );
+            const managedPreviewForPr = (release) => {
+              if (!release.prerelease || typeof release.body !== "string") {
+                return false;
+              }
+              if (!release.body.includes("Managed-By: hacs-preview")) {
+                return false;
+              }
+              return release.body.match(/Preview-PR: (\d+)/)?.[1] === prNumber;
+            };
+
+            const matching = releases.filter(managedPreviewForPr);
 
             for (const release of matching) {
               await deleteReleaseAndTag(release);
@@ -310,13 +315,15 @@ jobs:
               per_page: 100,
             });
 
-            const currentPreviewExists = releases.some((release) =>
-              release.prerelease &&
-              typeof release.body === "string" &&
-              release.body.includes("Managed-By: hacs-preview") &&
-              release.body.includes(`Preview-PR: ${prNumber}`) &&
-              release.body.includes(`Commit: ${sha}`)
-            );
+            const currentPreviewExists = releases.some((release) => {
+              if (!release.prerelease || typeof release.body !== "string") {
+                return false;
+              }
+              if (!release.body.includes("Managed-By: hacs-preview")) {
+                return false;
+              }
+              return release.body.match(/Preview-PR: (\d+)/)?.[1] === prNumber && release.body.includes(`Commit: ${sha}`);
+            });
 
             if (currentPreviewExists) {
               core.info(`Preview for PR #${prNumber} already points to ${sha}; skipping scheduled rebuild.`);
@@ -390,7 +397,7 @@ jobs:
               return;
             }
 
-      - name: Remove outdated preview for this PR and compute next sequence
+      - name: Compute next preview sequence
         if: steps.freshness.outputs.should_publish == 'true'
         id: sequence
         uses: actions/github-script@v8
@@ -400,23 +407,14 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const prNumber = process.env.PREVIEW_PR;
-
-            const deleteReleaseAndTag = async (release) => {
-              core.info(`Deleting preview release ${release.tag_name}`);
-              await github.rest.repos.deleteRelease({
-                owner,
-                repo,
-                release_id: release.id,
-              });
-              try {
-                await github.rest.git.deleteRef({
-                  owner,
-                  repo,
-                  ref: `tags/${release.tag_name}`,
-                });
-              } catch (error) {
-                core.warning(`Could not delete tag ${release.tag_name}: ${error.message}`);
+            const managedPreviewForPr = (release) => {
+              if (!release.prerelease || typeof release.body !== "string") {
+                return false;
               }
+              if (!release.body.includes("Managed-By: hacs-preview")) {
+                return false;
+              }
+              return release.body.match(/Preview-PR: (\d+)/)?.[1] === prNumber;
             };
 
             const releases = await github.paginate(github.rest.repos.listReleases, {
@@ -425,12 +423,7 @@ jobs:
               per_page: 100,
             });
 
-            const matching = releases.filter((release) =>
-              release.prerelease &&
-              typeof release.body === "string" &&
-              release.body.includes("Managed-By: hacs-preview") &&
-              release.body.includes(`Preview-PR: ${prNumber}`)
-            );
+            const matching = releases.filter(managedPreviewForPr);
 
             let nextSuffixNumber = 0;
             for (const release of matching) {
@@ -439,10 +432,6 @@ jobs:
                 const existingSuffixNumber = match[1] ? Number(match[1]) : 0;
                 nextSuffixNumber = Math.max(nextSuffixNumber, existingSuffixNumber + 1);
               }
-            }
-
-            for (const release of matching) {
-              await deleteReleaseAndTag(release);
             }
 
             core.setOutput("value", String(nextSuffixNumber));
@@ -504,7 +493,7 @@ jobs:
               "---",
               "",
               "Preview release for testing this PR in HACS.",
-              "It is automatically replaced when the PR is updated and removed when the PR is closed or merged."
+              "Older previews for the same PR are pruned automatically; the latest 5 are retained until the PR is closed or merged."
             );
 
             const hiddenMetadata = [
@@ -531,6 +520,65 @@ jobs:
 
             core.setOutput("html_url", created.html_url);
             core.setOutput("tag", created.tag_name);
+
+      - name: Keep latest preview releases for this PR
+        if: steps.freshness.outputs.should_publish == 'true'
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_PR: ${{ steps.pr.outputs.number }}
+          RETENTION_LIMIT: "5"
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = process.env.PREVIEW_PR;
+            const retentionLimit = Number(process.env.RETENTION_LIMIT || "5");
+            const managedPreviewForPr = (release) => {
+              if (!release.prerelease || typeof release.body !== "string") {
+                return false;
+              }
+              if (!release.body.includes("Managed-By: hacs-preview")) {
+                return false;
+              }
+              return release.body.match(/Preview-PR: (\d+)/)?.[1] === prNumber;
+            };
+
+            const deleteReleaseAndTag = async (release) => {
+              core.info(`Deleting old preview release ${release.tag_name}`);
+              await github.rest.repos.deleteRelease({
+                owner,
+                repo,
+                release_id: release.id,
+              });
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `tags/${release.tag_name}`,
+                });
+              } catch (error) {
+                core.warning(`Could not delete tag ${release.tag_name}: ${error.message}`);
+              }
+            };
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const matching = releases
+              .filter(managedPreviewForPr)
+              .sort((left, right) => {
+                const createdDiff = Date.parse(right.created_at) - Date.parse(left.created_at);
+                return createdDiff || right.id - left.id;
+              });
+
+            core.info(`Found ${matching.length} managed preview release(s) for PR #${prNumber}.`);
+            const stale = matching.slice(retentionLimit);
+            for (const release of stale) {
+              await deleteReleaseAndTag(release);
+            }
+            core.info(`Kept ${Math.min(matching.length, retentionLimit)} latest managed preview release(s) for PR #${prNumber}.`);
 
       - name: Comment on pull request
         if: steps.freshness.outputs.should_publish == 'true' && github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'

--- a/.github/workflows/hacs-preview.yml
+++ b/.github/workflows/hacs-preview.yml
@@ -23,6 +23,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  issues: write
   checks: read
 
 env:

--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -1145,6 +1145,9 @@ class SolaXModbusHub:
     async def async_connect(self) -> None:
         if getattr(self, "_stopping", False):
             return
+        if self._client.connected:
+            _LOGGER.debug(f"{self._name}: async_connect skipped - already connected")
+            return
         _LOGGER.debug(
             f"{self._name}: Trying to connect to Inverter at {self._client.comm_params.host}:{self._client.comm_params.port} connected: {self._client.connected} ",
         )
@@ -1166,13 +1169,11 @@ class SolaXModbusHub:
             except ModbusException as exception_error:
                 error = f"Error: device: {unit} address: 0x{address:x} -> {exception_error!s}"
                 _LOGGER.error(error)
-                # Flush transport: close + short pause + reconnect to clear any late/queued frames
-                _LOGGER.debug(f"{self._name}: ModbusException – flushing transport and reconnecting")
-                try:
-                    self._client.close()
-                finally:
-                    await asyncio.sleep(0.2)
-                    await self._client.connect()
+                if getattr(self, "_stopping", False):
+                    _LOGGER.debug(f"{self._name}: ModbusException during shutdown - skipping reconnect")
+                    return None
+                _LOGGER.debug(f"{self._name}: ModbusException – closing transport and deferring reconnect")
+                self._client.close()
                 return None
         return resp
 
@@ -1192,13 +1193,11 @@ class SolaXModbusHub:
             except ModbusException as exception_error:
                 error = f"Error: device: {unit} address: 0x{address:x} -> {exception_error!s}"
                 _LOGGER.error(error)
-                # Flush transport: close + short pause + reconnect to clear any late/queued frames
-                _LOGGER.debug(f"{self._name}: ModbusException – flushing transport and reconnecting")
-                try:
-                    self._client.close()
-                finally:
-                    await asyncio.sleep(0.2)
-                    await self._client.connect()
+                if getattr(self, "_stopping", False):
+                    _LOGGER.debug(f"{self._name}: ModbusException during shutdown - skipping reconnect")
+                    return None
+                _LOGGER.debug(f"{self._name}: ModbusException – closing transport and deferring reconnect")
+                self._client.close()
                 return None
         return resp
 

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -118,9 +118,17 @@ ALL_PM_GROUP = PM
 # Plugin-Level Register Validation
 # ============================================================================
 
-# Global storage for last known good values
-_pm_last_known_values: dict[str, Any] = {}
-_soc_last_known_values: dict[str, Any] = {}
+def _validation_cache(datadict: dict[str, Any], key: str) -> dict[str, Any]:
+    """Return a per-hub cache stored inside the hub data dict."""
+    cache = datadict.get("_validation_cache")
+    if not isinstance(cache, dict):
+        cache = {}
+        datadict["_validation_cache"] = cache
+    scoped = cache.get(key)
+    if not isinstance(scoped, dict):
+        scoped = {}
+        cache[key] = scoped
+    return scoped
 
 
 def validate_register_data(descr: Any, value: Any, datadict: dict[str, Any]) -> Any:
@@ -129,7 +137,8 @@ def validate_register_data(descr: Any, value: Any, datadict: dict[str, Any]) -> 
     - PM U32 sensors: detect 0xFFFFFF00 overflow pattern and use last known value.
     - battery_capacity: treat zero SoC as invalid and use last known value.
     """
-    global _pm_last_known_values, _soc_last_known_values
+    pm_last_known_values = _validation_cache(datadict, "pm_last_known_values")
+    soc_last_known_values = _validation_cache(datadict, "soc_last_known_values")
 
     if descr.key == "battery_capacity":
         try:
@@ -138,7 +147,7 @@ def validate_register_data(descr: Any, value: Any, datadict: dict[str, Any]) -> 
             soc_value = None
 
         if soc_value is not None and soc_value == 0:
-            last_value = _soc_last_known_values.get(descr.key)
+            last_value = soc_last_known_values.get(descr.key)
             if last_value is not None and last_value > 5:
                 # Only treat zero as invalid when a real SoC was seen before.
                 _LOGGER.warning(f"SoC zero reading for {descr.key} -> using last: {last_value}%")
@@ -146,24 +155,24 @@ def validate_register_data(descr: Any, value: Any, datadict: dict[str, Any]) -> 
             return value
 
         if soc_value is not None and soc_value > 0:
-            _soc_last_known_values[descr.key] = value
+            soc_last_known_values[descr.key] = value
 
     # PM U32 sensors only (filter by key prefix)
     if descr.key.startswith("pm_") and descr.register_data_type == REGISTER_U32:
         # Handle None from core errors
         if value is None:
-            last_value = _pm_last_known_values.get(descr.key, 0)
+            last_value = pm_last_known_values.get(descr.key, 0)
             _LOGGER.warning(f"PM sensor {descr.key} received None -> using last: {last_value}W")
             return last_value
 
         # Handle U32 overflow pattern
         if value >= 0xFFFFFF00:
-            last_value = _pm_last_known_values.get(descr.key, 0)
+            last_value = pm_last_known_values.get(descr.key, 0)
             _LOGGER.warning(f"PM U32 overflow {descr.key}: 0x{value:08X} -> using last: {last_value}W")
             return last_value
 
         # Store valid values for future use
-        _pm_last_known_values[descr.key] = value
+        pm_last_known_values[descr.key] = value
 
     return value
 

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -119,6 +119,7 @@ ALL_PM_GROUP = PM
 # Plugin-Level Register Validation
 # ============================================================================
 
+
 def _validation_cache(datadict: dict[str, Any], key: str) -> dict[str, Any]:
     """Return a per-hub cache stored inside the hub data dict."""
     cache = datadict.get("_validation_cache")


### PR DESCRIPTION
## Summary
- keep the latest 5 managed HACS preview pre-releases per PR instead of deleting every older preview
- only prune releases created by this workflow with matching `Managed-By: hacs-preview` and exact `Preview-PR` metadata
- keep cleanup-on-close behavior for all managed previews of the closed PR

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hacs-preview.yml"); puts "yaml ok"'`\n- `actionlint` not available locally